### PR TITLE
Prevent duplicate user for interactions

### DIFF
--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -108,6 +108,7 @@ class Message:
         self.content = message.get("content", "")
         self.id = message["id"]
         self.webhook_id = message.get("webhook_id", "")
+        self.application_id = message.get("application_id", "")
 
         self.mentions = [
             User(mention) for mention in message.get("mentions", [])

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -490,7 +490,7 @@ class DiscordClient(Gateway):
         Discord user.
         """
 
-        if message.webhook_id:
+        if message.webhook_id and not message.application_id:
             hashed = hash_str(message.author.username)
             message.author.id = str(int(message.author.id) + hashed)
 


### PR DESCRIPTION
Prevent the creating of a duplicate user on discord interactions like slash commands.

Interactions responses will now use the same matrix user as the normal messages by their bot.

Applications without a bot user will also only create a single matrix user.