### PR TITLE
Make Discord id length variable

### DIFF
--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -106,6 +106,7 @@ class Message:
         self.channel_id = message["channel_id"]
         self.content = message.get("content", "")
         self.id = message["id"]
+        self.guild_id = message.get("guild_id", "")
         self.webhook_id = message.get("webhook_id", "")
         self.application_id = message.get("application_id", "")
 

--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -106,7 +106,7 @@ class Message:
         self.channel_id = message["channel_id"]
         self.content = message.get("content", "")
         self.id = message["id"]
-        self.guild_id = message.get("guild_id", "")
+        self.guild_id = message["guild_id"]
         self.webhook_id = message.get("webhook_id", "")
         self.application_id = message.get("application_id", "")
 

--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from misc import dict_cls
 
 CDN_URL = "https://cdn.discordapp.com"
-ID_LEN = 18
 MESSAGE_LIMIT = 2000
 
 

--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -106,7 +106,9 @@ class Message:
         self.channel_id = message["channel_id"]
         self.content = message.get("content", "")
         self.id = message["id"]
-        self.guild_id = message.get("guild_id", "") # Responses for sending webhook messages don't have guild_id
+        self.guild_id = message.get(
+            "guild_id", ""
+        )  # Responses for sending webhook messages don't have guild_id
         self.webhook_id = message.get("webhook_id", "")
         self.application_id = message.get("application_id", "")
 

--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -108,6 +108,7 @@ class Message:
         self.content = message.get("content", "")
         self.id = message["id"]
         self.webhook_id = message.get("webhook_id", "")
+        self.application_id = message.get("application_id", "")
 
         self.mentions = [
             User(mention) for mention in message.get("mentions", [])

--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -106,7 +106,7 @@ class Message:
         self.channel_id = message["channel_id"]
         self.content = message.get("content", "")
         self.id = message["id"]
-        self.guild_id = message.get("guild_id", "")
+        self.guild_id = message.get("guild_id", "") # Responses for sending webhook messages don't have guild_id
         self.webhook_id = message.get("webhook_id", "")
         self.application_id = message.get("application_id", "")
 

--- a/appservice/discord.py
+++ b/appservice/discord.py
@@ -106,7 +106,7 @@ class Message:
         self.channel_id = message["channel_id"]
         self.content = message.get("content", "")
         self.id = message["id"]
-        self.guild_id = message["guild_id"]
+        self.guild_id = message.get("guild_id", "")
         self.webhook_id = message.get("webhook_id", "")
         self.application_id = message.get("application_id", "")
 

--- a/appservice/gateway.py
+++ b/appservice/gateway.py
@@ -148,6 +148,15 @@ class Gateway:
 
         return dict_cls(resp, discord.Channel)
 
+    def get_channels(self, guild_id: str) -> dict[str, discord.Channel]:
+        """
+        Get all channels for a given guild ID.
+        """
+
+        resp = self.send("GET", f"/guilds/{guild_id}/channels")
+
+        return {channel["id"]: dict_cls(channel, discord.Channel) for channel in resp}
+
     def get_emotes(self, guild_id: str) -> List[discord.Emote]:
         """
         Get all the emotes for a given guild.

--- a/appservice/gateway.py
+++ b/appservice/gateway.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import urllib.parse
-from typing import List
+from typing import List, Dict
 
 import urllib3
 import websockets
@@ -148,7 +148,7 @@ class Gateway:
 
         return dict_cls(resp, discord.Channel)
 
-    def get_channels(self, guild_id: str) -> dict[str, discord.Channel]:
+    def get_channels(self, guild_id: str) -> Dict[str, discord.Channel]:
         """
         Get all channels for a given guild ID.
         """

--- a/appservice/gateway.py
+++ b/appservice/gateway.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import urllib.parse
-from typing import List, Dict
+from typing import Dict, List
 
 import urllib3
 import websockets
@@ -155,7 +155,10 @@ class Gateway:
 
         resp = self.send("GET", f"/guilds/{guild_id}/channels")
 
-        return {channel["id"]: dict_cls(channel, discord.Channel) for channel in resp}
+        return {
+            channel["id"]: dict_cls(channel, discord.Channel)
+            for channel in resp
+        }
 
     def get_emotes(self, guild_id: str) -> List[discord.Emote]:
         """

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -5,11 +5,11 @@ import os
 import re
 import sys
 import threading
+import urllib.parse
 from typing import Dict, List, Tuple
 
 import markdown
 import urllib3
-import urllib.parse
 
 import discord
 import matrix
@@ -351,12 +351,18 @@ height=\"32\" src=\"{emote_}\" data-mx-emoticon />""",
         emotes = re.findall(r":(\w*):", message)
 
         mentions = list(
-            re.finditer(self.mention_regex(encode=False, id_as_group=True), event.formatted_body)
+            re.finditer(
+                self.mention_regex(encode=False, id_as_group=True),
+                event.formatted_body,
+            )
         )
         # For clients that properly encode mentions.
         # 'https://matrix.to/#/%40_discord_...%3Adomain.tld'
         mentions.extend(
-            re.finditer(self.mention_regex(encode=True, id_as_group=True), event.formatted_body)
+            re.finditer(
+                self.mention_regex(encode=True, id_as_group=True),
+                event.formatted_body,
+            )
         )
 
         with Cache.lock:
@@ -367,9 +373,9 @@ height=\"32\" src=\"{emote_}\" data-mx-emoticon />""",
 
         for mention in set(mentions):
             # Unquote just in-case we matched an encoded username.
-            username = self.db.fetch_user(urllib.parse.unquote(mention.group(0))).get(
-                "username"
-            )
+            username = self.db.fetch_user(
+                urllib.parse.unquote(mention.group(0))
+            ).get("username")
             if username:
                 if mention.group(2):
                     # Replace mention with plain text for hashed users (webhooks)
@@ -379,7 +385,9 @@ height=\"32\" src=\"{emote_}\" data-mx-emoticon />""",
                     # in the case of replies aswell.
                     # '> <@_discord_1234:localhost> Message'
                     for replace in (mention.group(0), username):
-                        message = message.replace(replace, f"<@{mention.group(1)}>")
+                        message = message.replace(
+                            replace, f"<@{mention.group(1)}>"
+                        )
 
         # We trim the message later as emotes take up extra characters too.
         return message[: discord.MESSAGE_LIMIT]
@@ -461,7 +469,7 @@ class DiscordClient(Gateway):
             or message.webhook_id in hook_ids
         )
 
-    def matrixify(self, id: str, user: bool = False, hashed: str = '') -> str:
+    def matrixify(self, id: str, user: bool = False, hashed: str = "") -> str:
         return (
             f"{'@' if user else '#'}{self.app.format}"
             f"{id}{'-' + hashed if hashed else ''}:"
@@ -496,7 +504,7 @@ class DiscordClient(Gateway):
         Discord user.
         """
 
-        hashed = ''
+        hashed = ""
         if message.webhook_id and message.webhook_id != message.application_id:
             hashed = str(hash_str(message.author.username))
 
@@ -676,13 +684,17 @@ class DiscordClient(Gateway):
         channels = re.findall("<#([0-9]+)>", content)
         if channels:
             if not message.guild_id:
-                self.logger.warning(f"Message '{message.id}' in channel '{message.channel_id}' does not have a guild_id!")
+                self.logger.warning(
+                    f"Message '{message.id}' in channel '{message.channel_id}' does not have a guild_id!"
+                )
             else:
                 discord_channels = self.get_channels(message.guild_id)
                 for channel in channels:
                     discord_channel = discord_channels.get(channel)
                     name = (
-                        discord_channel.name if discord_channel else "deleted-channel"
+                        discord_channel.name
+                        if discord_channel
+                        else "deleted-channel"
                     )
                     content = content.replace(f"<#{channel}>", f"#{name}")
 

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -665,14 +665,16 @@ class DiscordClient(Gateway):
                     f"<@{char}{member.id}>", f"@{member.username}"
                 )
 
-        # `except_deleted` for invalid channels.
-        # TODO can this block for too long ?
-        for channel in re.findall("<#([0-9]+)>", content):
-            discord_channel = except_deleted(self.get_channel)(channel)
-            name = (
-                discord_channel.name if discord_channel else "deleted-channel"
-            )
-            content = content.replace(f"<#{channel}>", f"#{name}")
+        # Replace channel IDs with names.
+        channels = re.findall("<#([0-9]+)>", content)
+        if channels:
+            discord_channels = self.get_channels(message.guild_id)
+            for channel in channels:
+                discord_channel = discord_channels.get(channel)
+                name = (
+                    discord_channel.name if discord_channel else "deleted-channel"
+                )
+                content = content.replace(f"<#{channel}>", f"#{name}")
 
         # { "emote_name": "emote_id" }
         for emote in re.findall(regex, content):

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -497,7 +497,7 @@ class DiscordClient(Gateway):
         """
 
         hashed = ''
-        if message.webhook_id and not message.application_id:
+        if message.webhook_id and message.webhook_id != message.application_id:
             hashed = str(hash_str(message.author.username))
 
         mxid = self.matrixify(message.author.id, user=True, hashed=hashed)
@@ -675,13 +675,16 @@ class DiscordClient(Gateway):
         # Replace channel IDs with names.
         channels = re.findall("<#([0-9]+)>", content)
         if channels:
-            discord_channels = self.get_channels(message.guild_id)
-            for channel in channels:
-                discord_channel = discord_channels.get(channel)
-                name = (
-                    discord_channel.name if discord_channel else "deleted-channel"
-                )
-                content = content.replace(f"<#{channel}>", f"#{name}")
+            if not message.guild_id:
+                self.logger.warning(f"Message '{message.id}' in channel '{message.channel_id}' does not have a guild_id!")
+            else:
+                discord_channels = self.get_channels(message.guild_id)
+                for channel in channels:
+                    discord_channel = discord_channels.get(channel)
+                    name = (
+                        discord_channel.name if discord_channel else "deleted-channel"
+                    )
+                    content = content.replace(f"<#{channel}>", f"#{name}")
 
         # { "emote_name": "emote_id" }
         for emote in re.findall(regex, content):

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -490,7 +490,7 @@ class DiscordClient(Gateway):
         Discord user.
         """
 
-        if message.webhook_id:
+        if message.webhook_id and not message.application_id:
             hashed = hash_str(message.author.username)
             message.author.id = str(int(message.author.id) + hashed)
 

--- a/appservice/misc.py
+++ b/appservice/misc.py
@@ -73,13 +73,12 @@ def except_deleted(fn):
 
 def hash_str(string: str) -> int:
     """
-    Create the hash for a string (poorly).
+    Create the hash for a string
     """
 
-    hashed = 0
-    results = map(ord, string)
+    hash = 5381
 
-    for result in results:
-        hashed += result
+    for ch in string:
+        hash = ((hash << 5) + hash) + ord(ch)
 
-    return hashed
+    return hash & 0xFFFFFFFF


### PR DESCRIPTION
Fixed assumption of discord ids being always 18 characters long, they are based on a timestamp and older account have shorter ids and future accounts might have even longer ones. There is no good regex for ids besides `[0-9]+` really.

I also improved the matrix mention to discord mention replace to save a regex match. I added `id_as_group` as an argument to `mention_regex()` in case the old functionality without group is needed somewhere. Using `re.finditer()` instead of `re.findall` to get a match object that has the full matched string and not just the group match.