### PR TITLE
Add HTML parser for Matrix messages

### DIFF
--- a/appservice/main.py
+++ b/appservice/main.py
@@ -6,7 +6,7 @@ import re
 import sys
 import threading
 import urllib.parse
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Tuple, Optional
 
 import markdown
 import urllib3

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -173,7 +173,7 @@ class MatrixClient(AppService):
     def parse_message(self, message: matrix.Event, limit: int = discord.MESSAGE_LIMIT, generate_link: bool = True):
         if message.formatted_body:
             msg_link = self.create_msg_link(message.room_id, message.id) if generate_link else ""
-            parser = MatrixParser(self.db, self.mention_regex(False, True), limit=limit-len(msg_link))
+            parser = MatrixParser(self.db, self.mention_regex(False, True), self.mxc_url, limit=limit-len(msg_link))
             try:
                 parser.feed(message.formatted_body)
             except StopIteration:

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -18,7 +18,7 @@ from cache import Cache
 from db import DataBase
 from errors import RequestError
 from gateway import Gateway
-from message_parser import MatrixParser
+from message_parser import MatrixParser, escape_markdown
 from misc import dict_cls, except_deleted, hash_str
 
 
@@ -184,6 +184,8 @@ class MatrixClient(AppService):
                     message.body += msg_link
             else:
                 message.body = parser.message
+        else:
+            message.body = escape_markdown(message.body)
         return message.body
 
     def on_redaction(self, event: matrix.Event) -> None:

--- a/appservice/main.py
+++ b/appservice/main.py
@@ -89,7 +89,7 @@ class MatrixClient(AppService):
 
     def append_replied_to_msg(self, message: matrix.Event) -> str:
         def escape_urls(message_: str):
-            return re.sub(r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", "<\g<0>>", message_)
+            return re.sub(r"(?<!<)http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", "<\g<0>>", message_)
         if message.reply and message.reply.get("event_id"):
             replied_to_body: Optional[matrix.Event] = except_deleted(self.get_event)(message.reply["event_id"], message.room_id)
             if replied_to_body and not replied_to_body.redacted_because:

--- a/appservice/matrix.py
+++ b/appservice/matrix.py
@@ -20,9 +20,10 @@ class Event:
         self.room_id = event["room_id"]
         self.sender = event["sender"]
         self.state_key = event.get("state_key", "")
-
+        self.redacted_because = event.get("redacted_because", {})
         rel = content.get("m.relates_to", {})
 
         self.relates_to = rel.get("event_id")
         self.reltype = rel.get("rel_type")
-        self.new_body = content.get("m.new_content", {}).get("body", "")
+        self.reply: dict = rel.get("m.in_reply_to")
+        self.new_body = content.get("m.new_content", {})

--- a/appservice/message_parser.py
+++ b/appservice/message_parser.py
@@ -1,7 +1,7 @@
 import re
 import logging
 from html.parser import HTMLParser
-from typing import Optional, Tuple, List, Callable
+from typing import Optional, Tuple, List
 
 from db import DataBase
 from cache import Cache

--- a/appservice/message_parser.py
+++ b/appservice/message_parser.py
@@ -11,6 +11,7 @@ headers = {"h1": "***__", "h2": "**__", "h3": "**", "h4": "__", "h5": "*", "h6":
 
 logger = logging.getLogger("message_parser")
 
+
 def search_attr(attrs: List[Tuple[str, Optional[str]]], searched: str) -> Optional[str]:
     for attr in attrs:
         if attr[0] == searched:
@@ -20,7 +21,58 @@ def search_attr(attrs: List[Tuple[str, Optional[str]]], searched: str) -> Option
 
 def escape_markdown(to_escape: str):
     to_escape.replace("\\", "\\\\")
-    return re.sub(r"([`_*~:<>{}@|])", r"\\\1", to_escape)
+    return re.sub(r"([`_*~:<>{}@|(])", r"\\\1", to_escape)
+
+
+class Tags(object):
+    def __init__(self):
+        self.c_tags = []
+        self.length = 0
+
+    @staticmethod
+    def _gauge_length(tag: str) -> int:
+        if tag in htmltomarkdown:
+            return len(htmltomarkdown.get(tag))
+        elif tag == "spoiler":
+            return 2
+        elif tag == "pre":
+            return 3
+        elif tag == "code":
+            return 1
+        return 0
+
+    def append(self, tag: str):
+        self.c_tags.append(tag)
+        self.length += self._gauge_length(tag)
+
+    def pop(self) -> Optional[str]:
+        try:
+            last_tag = self.c_tags.pop()
+            self.length -= self._gauge_length(last_tag)
+            return last_tag
+        except IndexError:
+            return None
+
+    def get_last(self) -> Optional[str]:
+        try:
+            return self.c_tags[-1]
+        except IndexError:
+            return None
+
+    def get_size(self) -> int:
+        return self.length
+
+    def __reversed__(self):
+        return iter(self.c_tags[::-1])
+
+    def __len__(self):
+        return len(self.c_tags)
+
+    def __iter__(self):
+        return iter(self.c_tags)
+
+    def __bool__(self):
+        return bool(self.c_tags)
 
 
 class MatrixParser(HTMLParser):
@@ -28,23 +80,24 @@ class MatrixParser(HTMLParser):
         super().__init__()
         self.message: str = ""
         self.current_link: str = ""
-        self.c_tags: list[str] = []
+        self.tags: Tags = Tags()
         self.list_num: int = 1
         self.db: DataBase = db
         self.snowflake_regex: str = mention_regex
-        self.limit = limit
+        self.limit: int = limit
+        self.overflow: bool = False
 
     def search_for_feature(self, acceptable_features: Tuple[str, ...]) -> Optional[str]:
         """Searches for certain feature in opened HTML tags for given text, if found returns the tag, if not returns None"""
-        for tag in self.c_tags[::-1]:
+        for tag in reversed(self.tags):
             if tag in acceptable_features:
                 return tag
         return None
 
     def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]):
-        if "mx-reply" in self.c_tags:
+        if "mx-reply" in self.tags:
             return
-        self.c_tags.append(tag)
+        self.tags.append(tag)
 
         if tag in htmltomarkdown:
             self.expand_message(htmltomarkdown[tag])
@@ -59,7 +112,7 @@ class MatrixParser(HTMLParser):
                 if spoiler:  # Spoilers can have a reason https://github.com/matrix-org/matrix-doc/pull/2010
                     self.expand_message(f"({spoiler})")
                 self.expand_message("||")
-                self.c_tags.append("spoiler")  # Always after span tag
+                self.tags.append("spoiler")  # Always after span tag
         elif tag == "li":
             list_type = self.search_for_feature(("ul", "ol"))
             if list_type == "ol":
@@ -85,6 +138,9 @@ class MatrixParser(HTMLParser):
                 self.expand_message(emote_name)
         elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
             self.expand_message(headers[tag])
+        elif tag == "hr":
+            self.expand_message("\n---\n")
+            self.tags.pop()
 
     def parse_mentions(self, attrs):
         self.current_link = search_attr(attrs, "href")
@@ -104,8 +160,17 @@ class MatrixParser(HTMLParser):
             # Matrix user, not Discord appservice account
             return ""
 
+    def close_tags(self):
+        for tag in reversed(self.tags):
+            self.handle_endtag(tag)
+
     def expand_message(self, expansion: str):
-        if len(self.message) + len(expansion) > self.limit:  # TODO Close all tags in c_tags?
+        # This calculation is not ideal. self.limit is further restricted by message link length, so if a message
+        # doesn't really go over the limit but message + message link does it will still treat it as out of the limit
+        if len(self.message) + self.tags.get_size() + len(expansion) > self.limit and self.overflow is False:
+            # Lets close all of the tags to make sure we don't have display errors
+            self.overflow = True
+            self.close_tags()
             raise StopIteration
         self.message += expansion
 
@@ -113,10 +178,10 @@ class MatrixParser(HTMLParser):
         return bool(self.db.fetch_user(target))
 
     def handle_data(self, data):
-        if self.c_tags:
-            if self.c_tags[-1] != "code":
+        if self.tags:
+            if self.tags.get_last() != "code":
                 data = escape_markdown(data.replace("\n", ""))
-            if "mx-reply" in self.c_tags:
+            if "mx-reply" in self.tags:
                 return
         if self.current_link:
             self.expand_message(f"[{data}](<{self.current_link}>)")
@@ -127,18 +192,17 @@ class MatrixParser(HTMLParser):
             self.expand_message(data)  # strip new lines, they will be mostly handled by parser
 
     def handle_endtag(self, tag: str):
-        if "mx-reply" in self.c_tags and tag != "mx-reply":
+        if "mx-reply" in self.tags and tag != "mx-reply":
             return
         if tag in htmltomarkdown:
             self.expand_message(htmltomarkdown[tag])
-        try:
-            last_tag = self.c_tags.pop()
-        except IndexError:
+        last_tag = self.tags.pop()
+        if last_tag is None:
             logger.error("tried to pop {} from message tags but list is empty, current message {}".format(tag, self.message))
             return
         if last_tag == "spoiler":
             self.expand_message("||")
-            self.c_tags.pop()  # guaranteed to be a span tag
+            self.tags.pop()  # guaranteed to be a span tag
         if tag == "ol":
             self.list_num = 1
         elif tag == "code":

--- a/appservice/message_parser.py
+++ b/appservice/message_parser.py
@@ -149,7 +149,7 @@ class MatrixParser(HTMLParser):
                 self.expand_message("\n")
             self.expand_message(headers[tag])
         elif tag == "hr":
-            self.expand_message("\n---\n")
+            self.expand_message("\n──────────\n")
             self.tags.pop()
 
     def parse_mentions(self, attrs):

--- a/appservice/message_parser.py
+++ b/appservice/message_parser.py
@@ -1,0 +1,148 @@
+import re
+from html.parser import HTMLParser
+from typing import Optional, Tuple, List, Callable
+
+from db import DataBase
+from cache import Cache
+
+htmltomarkdown = {"p": "\n", "strong": "**", "ins": "__", "u": "__", "b": "**", "em": "*", "i": "*", "del": "~~", "strike": "~~", "s": "~~"}
+headers = {"h1": "***__", "h2": "**__", "h3": "**", "h4": "__", "h5": "*", "h6": ""}
+
+
+def search_attr(attrs: List[Tuple[str, Optional[str]]], searched: str) -> Optional[str]:
+    for attr in attrs:
+        if attr[0] == searched:
+            return attr[1] or ""
+    return None
+
+
+def escape_markdown(to_escape: str):
+    to_escape.replace("\\", "\\\\")
+    return re.sub(r"([`_*~:<>{}@|])", r"\\\1", to_escape)
+
+
+class MatrixParser(HTMLParser):
+    def __init__(self, db: DataBase, mention_regex: str, limit: int = 0):
+        super().__init__()
+        self.message: str = ""
+        self.current_link: str = ""
+        self.c_tags: list[str] = []
+        self.list_num: int = 1
+        self.db: DataBase = db
+        self.snowflake_regex: str = mention_regex
+        self.limit = limit
+
+    def search_for_feature(self, acceptable_features: Tuple[str, ...]) -> Optional[str]:
+        """Searches for certain feature in opened HTML tags for given text, if found returns the tag, if not returns None"""
+        for tag in self.c_tags[::-1]:
+            if tag in acceptable_features:
+                return tag
+        return None
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]):
+        if "mx-reply" in self.c_tags:
+            return
+        self.c_tags.append(tag)
+        if tag in htmltomarkdown:
+            self.expand_message(htmltomarkdown[tag])
+        elif tag == "code":
+            if self.search_for_feature(("pre",)):
+                self.expand_message("```" + (search_attr(attrs, "class") or "")[9:] + "\n")
+            else:
+                self.expand_message("`")
+        elif tag == "span":
+            spoiler = search_attr(attrs, "data-mx-spoiler")
+            if spoiler is not None:
+                if spoiler:  # Spoilers can have a reason https://github.com/matrix-org/matrix-doc/pull/2010
+                    self.expand_message(f"({spoiler})")
+                self.expand_message("||")
+                self.c_tags.append("spoiler")  # Always after span tag
+        elif tag == "li":
+            list_type = self.search_for_feature(("ul", "ol"))
+            if list_type == "ol":
+                self.expand_message("\n{}. ".format(self.list_num))
+                self.list_num += 1
+            else:
+                self.expand_message("\n• ")
+        elif tag in "br":
+            self.c_tags.pop()
+            self.expand_message("\n")
+            if self.search_for_feature(("blockquote",)):
+                self.expand_message("> ")
+        elif tag == "p":
+            self.expand_message("\n")
+        elif tag == "a":
+            self.parse_mentions(attrs)
+        elif tag == "mx-reply":  # we handle replies separately for best effect
+            return
+        elif tag == "img":  # TODO At least make it a link to Matrix URL
+            emote_name = search_attr(attrs, "title")
+            emote_ = Cache.cache["d_emotes"].get(emote_name)
+            if emote_:
+                self.expand_message(emote_)
+            else:
+                self.expand_message(emote_name)
+        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self.expand_message(headers[tag])
+        elif tag == "blockquote":
+            self.expand_message("> ")
+        # ignore font tag
+
+    def parse_mentions(self, attrs):
+        self.current_link = search_attr(attrs, "href")
+        if self.current_link.startswith("https://matrix.to/#/"):
+            target = self.current_link[20:]
+            if target.startswith("@"):
+                self.expand_message(self.parse_user(target.split("?")[0]))
+            # Rooms will be handled by handle_data on data
+
+    def parse_user(self, target: str):
+        if self.is_discord_user(target):
+            snowflake = re.search(re.compile(self.snowflake_regex), target).group(1)
+            if snowflake:
+                self.current_link = None  # Meaning, skip adding text
+                return f"<@{snowflake}>"
+        else:
+            # Matrix user, not Discord appservice account
+            return ""
+
+    def expand_message(self, expansion: str):
+        if len(self.message) + len(expansion) > self.limit:  # TODO Close all tags in c_tags?
+            self.close()
+        self.message += expansion
+
+    def is_discord_user(self, target: str) -> bool:
+        return bool(self.db.fetch_user(target))
+
+    def handle_data(self, data):
+        if self.c_tags:
+            if self.c_tags[-1] != "code":
+                data = escape_markdown(data.replace("\n", ""))
+            if "mx-reply" in self.c_tags:
+                return
+        if self.current_link:
+            self.expand_message(f"[{data}](<{self.current_link}>)")
+            self.current_link = ""
+        elif self.current_link is None:
+            self.current_link = ""
+        else:
+            self.expand_message(data)  # strip new lines, they will be mostly handled by parser
+
+    def handle_endtag(self, tag: str):
+        if "mx-reply" in self.c_tags and tag != "mx-reply":
+            return
+        if tag in htmltomarkdown:
+            self.expand_message(htmltomarkdown[tag])
+        last_tag = self.c_tags.pop()
+        if last_tag == "spoiler":
+            self.expand_message("||")
+            self.c_tags.pop()  # guaranteed to be a span tag
+        if tag == "ol":
+            self.list_num = 1
+        elif tag == "code":
+            if self.search_for_feature(("pre",)):
+                self.expand_message("\n```")
+            else:
+                self.expand_message("`")
+        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self.expand_message(headers[tag][::-1])


### PR DESCRIPTION
Sometimes Matrix messages are more complex and are expressed with HTML markup. This introduces some challenges with bridging such messages to Matrix. Things like spoilers, lists, headers, code blocks should be expressed properly on Discord side as well. Projects that focus on converting messages back and fourth between two platforms [already exist](https://github.com/matrix-discord/matrix-discord-parser) but I haven't found similar converter for Python. 

Worth noting that `Use embeds on Discord side for replies.` is on TODO list for the project, however this PR still uses non embed way of replies. Yet with changes in this PR I think it should be easier to complete that TODO in the future (even though it is not my goal for this PR to accomplish that).

This PR does not introduce any new external dependencies. 

Currently PR is in draft mode until I finish working with it completely (most notably, emoji conversion should be done, also, polishing and bug squashing). Wanted to create this PR before I finish to extend the time for discussion over this PR. 
I'm personally running modified branch with those changes on my own server however additional testing and feedback is appreciated.